### PR TITLE
referenceField: properly handle default props

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -26,7 +26,9 @@ export const PostList = (props) => (
 All field components accept the following attributes:
 
 * `source`: Property name of your entity to view/edit. This attribute is required.
-* `label`: Used as a table header of an input label. Defaults to the `source` when omitted.
+* `label`: In a datagrid, used as a table header of an input label.
+Otherwise define the field label. Defaults to the `source` when omitted.
+* `addLabel`: Defined the visibility of the label when the field is not in a datagrid, default value is ```true```.
 * `sortable`: Should the list be sortable using `source` attribute? Defaults to `true`.
 * `elStyle`: A style object to customize the look and feel of the field element itself
 * `style`: A style object to customize the look and feel of the field container (e.g. the `<td>` in a datagrid).
@@ -402,15 +404,6 @@ You can also prevent `<ReferenceField>` from adding link to children by setting 
 ```jsx
 // No link
 <ReferenceField label="User" source="userId" reference="users" linkType={false}>
-    <TextField source="name" />
-</ReferenceField>
-```
-
-If you are using the field in `<Edit>` or `<Show>` page, you might want to display the label associated with the field you are displaying. In that case, simply add the `addLabel` prop to `<ReferenceField>` to make the `source` prop visible on top of the field, or the optional `label` prop if you want to personalize it.
-
-```jsx
-// Display 'User' Label on top of the TexField
-<ReferenceField addLabel label="User" source="userId" reference="users">
     <TextField source="name" />
 </ReferenceField>
 ```

--- a/example/app.js
+++ b/example/app.js
@@ -9,7 +9,7 @@ import frenchMessages from 'aor-language-french';
 import addUploadFeature from './addUploadFeature';
 
 import { PostList, PostCreate, PostEdit, PostShow, PostIcon } from './posts';
-import { CommentList, CommentEdit, CommentCreate, CommentIcon } from './comments';
+import { CommentList, CommentEdit, CommentCreate, CommentIcon, CommentShow } from './comments';
 
 import data from './data';
 import * as customMessages from './i18n';
@@ -27,7 +27,7 @@ const delayedRestClient = (type, resource, params) => new Promise(resolve => set
 render(
     <Admin authClient={authClient} restClient={delayedRestClient} title="Example Admin" locale="en" messages={messages}>
         <Resource name="posts" list={PostList} create={PostCreate} edit={PostEdit} show={PostShow} remove={Delete} icon={PostIcon} />
-        <Resource name="comments" list={CommentList} create={CommentCreate} edit={CommentEdit} remove={Delete} icon={CommentIcon} />
+        <Resource name="comments" list={CommentList} create={CommentCreate} show={CommentShow} edit={CommentEdit} remove={Delete} icon={CommentIcon} />
         <Resource name="tags" />
     </Admin>,
     document.getElementById('root'),

--- a/example/comments.js
+++ b/example/comments.js
@@ -20,6 +20,9 @@ import {
     TextInput,
     minLength,
     translate,
+    Show,
+    ShowButton,
+    SimpleShowLayout,
 } from 'admin-on-rest';
 import PersonIcon from 'material-ui/svg-icons/social/person';
 import Avatar from 'material-ui/Avatar';
@@ -83,6 +86,7 @@ const CommentGrid = translate(({ ids, data, basePath, translate }) => (
             </CardText>
             <CardActions style={{ textAlign: 'right' }}>
                 <EditButton resource="posts" basePath={basePath} record={data[id]} />
+                <ShowButton resource="posts" basePath={basePath} record={data[id]}/>
             </CardActions>
         </Card>,
     )}
@@ -135,4 +139,18 @@ export const CommentCreate = ({ ...props }) => (
             <LongTextInput source="body" />
         </SimpleForm>
     </Create>
+);
+
+export const CommentShow = ({...props}) => (
+    <Show {...props}>
+        <SimpleShowLayout>
+            <TextField source="id" />
+            <ReferenceField source="post_id" reference="posts">
+                <TextField source="title"/>
+            </ReferenceField>
+            <TextField source="author.name" />
+            <DateField source="created_at" />
+            <TextField source="body" />
+        </SimpleShowLayout>
+    </Show>
 );

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -100,9 +100,6 @@ ReferenceField.propTypes = {
 };
 
 ReferenceField.defaultProps = {
-    addLabel: true,
-    referenceRecord: null,
-    record: {},
     allowEmpty: false,
     linkType: 'edit',
 };
@@ -113,6 +110,14 @@ function mapStateToProps(state, props) {
     };
 }
 
-export default connect(mapStateToProps, {
+const ConnectedReferenceField = connect(mapStateToProps, {
     crudGetManyAccumulate: crudGetManyAccumulateAction,
 })(ReferenceField);
+
+ConnectedReferenceField.defaultProps = {
+    addLabel: true,
+    referenceRecord: null,
+    record: {},
+};
+
+export default ConnectedReferenceField;


### PR DESCRIPTION
Currently, the referencefield label is only shown when
addLabel is set. But by default, the label field should
show the label (based on default value).

So now the referenceField now shown the label by default
whithout use addLabel props.

This bug is due to the use of redux who ignored the
default props of the component.