### PR TITLE
ReferenceField: LinearProgress visible only when there are data

### DIFF
--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -37,6 +37,13 @@ import linkToRecord from '../../util/linkToRecord';
  * </ReferenceField>
  */
 export class ReferenceField extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showWaitBar: !this.props.allowEmpty,
+        }
+    }
+
     componentDidMount() {
         this.fetchReference(this.props);
     }
@@ -51,6 +58,7 @@ export class ReferenceField extends Component {
         const source = get(props.record, props.source);
         if (source !== null && typeof source !== 'undefined') {
             this.props.crudGetManyAccumulate(props.reference, [source]);
+            this.setState({showWaitBar: true});
         }
     }
 
@@ -59,7 +67,7 @@ export class ReferenceField extends Component {
         if (React.Children.count(children) !== 1) {
             throw new Error('<ReferenceField> only accepts a single child');
         }
-        if (!referenceRecord && !allowEmpty) {
+        if (this.state.showWaitBar && !referenceRecord) {
             return <LinearProgress />;
         }
         const rootPath = basePath.split('/').slice(0, -1).join('/');


### PR DESCRIPTION
LinearProgress is visible when there are data and not.

now if data is fetching LinearProgress is visible while the data
is load, and if data is empty is hidden as default