### PR TITLE
example: webpack, add the json loader

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     },
     module: {
         loaders: [
+            { test: /\.json/, loader: 'json-loader' },
             { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
             { test: /\.css$/, loader: 'style-loader!css-loader' },
        ],

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "file-api": "~0.10.4",
     "full-icu": "~1.0.3",
     "ignore-styles": "~5.0.1",
+    "json-loader": "^0.5.4",
     "mocha": "~3.2.0",
     "react-addons-test-utils": "~15.5.1",
     "selenium-webdriver": "~3.3.0",


### PR DESCRIPTION
Add a json loader because we are using webpack 1.X, and we will need it
to include the phonenumber library in the next commits.