### PR TITLE
admin-on-rest: SimpleList, add the ability to style items of SimpleList

### DIFF
--- a/src/mui/list/SimpleList.js
+++ b/src/mui/list/SimpleList.js
@@ -17,6 +17,7 @@ const SimpleList = ({
     leftIcon,
     rightAvatar,
     rightIcon,
+    itemStyle,
 }) => (
     <List>
         {ids.map(id => (
@@ -39,6 +40,7 @@ const SimpleList = ({
                 rightAvatar={rightAvatar && rightAvatar(data[id], id)}
                 rightIcon={rightIcon && rightIcon(data[id], id)}
                 containerElement={<Link to={`${basePath}/${id}`} />}
+                style={itemStyle}
             />
         ))}
     </List>
@@ -56,6 +58,7 @@ SimpleList.propTypes = {
     leftIcon: PropTypes.func,
     rightAvatar: PropTypes.func,
     rightIcon: PropTypes.func,
+    itemStyle: PropTypes.object,
 };
 
 export default SimpleList;


### PR DESCRIPTION
In order to gain some space with the icons and avatars in SimpleList,
we add a new props itemStyle who permits to modify the style of the
items.