### PR TITLE
sidebar: add backgroudColor property

### DIFF
--- a/src/mui/layout/Sidebar.js
+++ b/src/mui/layout/Sidebar.js
@@ -20,12 +20,14 @@ const getStyles = ({ drawer }) => {
             marginLeft: 0,
             order: -1,
             transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
+            backgroundColor: drawer.color,
         },
         sidebarClosed: {
             flex: `0 0 ${width}`,
             marginLeft: `-${width}`,
             order: -1,
             transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
+            backgroundColor: drawer.color,
         },
     });
 };


### PR DESCRIPTION
The sideBar layout is defined by a paper component from material ui.
This paper is used in adminOnRest list views and we just want
set backgroundColor for the sidebar only and not for the list to.
now we add backgroundColor property inherited to the drawer color
property. We do this in order to change the backgroundColor of the
sideBar and to have unifyed theme for lateral menu.