### PR TITLE
menuItemLink: add default style property

### DIFF
--- a/src/mui/layout/MenuItemLink.js
+++ b/src/mui/layout/MenuItemLink.js
@@ -9,6 +9,7 @@ export class MenuItemLinkComponent extends Component {
         history: PropTypes.object.isRequired,
         onTouchTap: PropTypes.func.isRequired,
         to: PropTypes.string.isRequired,
+        style: PropTypes.object,
     }
 
     handleMenuTap = () => {
@@ -17,11 +18,14 @@ export class MenuItemLinkComponent extends Component {
     }
     render() {
         const { history, match, location, staticContext, ...props } = this.props; // eslint-disable-line
-
+        const customStyle = {
+          color: 'white',
+        }
         return (
             <MenuItem
                 {...props}
                 onTouchTap={this.handleMenuTap}
+                style={customStyle}
             />
         );
     }


### PR DESCRIPTION
In the app the menuItemlink is defined with menuItem from material ui,
With material ui we can defined some style property but we can't change
text color property directely. Now we add default color property to the
menuItem of the sidebar. We do this in order to have a custom cleany
sidebar.