### PR TITLE
InfiniteList: page by page

### DIFF
--- a/src/mui/list/InfiniteList.js
+++ b/src/mui/list/InfiniteList.js
@@ -32,13 +32,13 @@ export class InfiniteList extends List {
     componentDidMount() {
         this.updateData();
         if (Object.keys(this.props.query).length > 0) {
-            this.props.query.page = 0;
+            this.props.query.page = 1;
             this.props.changeListParams(this.props.resource, this.props.query);
         }
     }
 
     componentWillUnmount() {
-        this.props.query.page = 0;
+        this.props.query.page = 1;
         this.props.changeListParams(this.props.resource, this.props.query);
     }
 


### PR DESCRIPTION
InfiniteList query all the pages because when we unmount and mount
the component we set the query page to 0 but the pagination should start
at 1, therefore postgres return an negative value that query all the
pages. Now we set this value to 1. we do this in order to fetch page
by page and in order to improuve render page rendering.