### PR TITLE
BooleanInput: change DefaultToggled to toggled

### DIFF
--- a/src/mui/input/BooleanInput.js
+++ b/src/mui/input/BooleanInput.js
@@ -35,7 +35,7 @@ class BooleanInput extends Component {
         return (
             <div style={elStyle || styles.block}>
                 <Toggle
-                    defaultToggled={!!input.value}
+                    toggled={!!input.value}
                     onToggle={this.handleToggle}
                     labelStyle={styles.label}
                     style={styles.toggle}

--- a/src/mui/input/BooleanInput.spec.js
+++ b/src/mui/input/BooleanInput.spec.js
@@ -16,19 +16,19 @@ describe('<BooleanInput />', () => {
         const wrapper = shallow(
             <BooleanInput source="foo" input={{ value: true }} />
         );
-        assert.equal(wrapper.find('Toggle').prop('defaultToggled'), true);
+        assert.equal(wrapper.find('Toggle').prop('toggled'), true);
     });
 
     it('should not be checked if the value is false', () => {
         const wrapper = shallow(
             <BooleanInput source="foo" input={{ value: false }} />
         );
-        assert.equal(wrapper.find('Toggle').prop('defaultToggled'), false);
+        assert.equal(wrapper.find('Toggle').prop('toggled'), false);
     });
 
     it('should not be checked if the value is undefined', () => {
         const wrapper = shallow(<BooleanInput source="foo" input={{}} />);
-        assert.equal(wrapper.find('Toggle').prop('defaultToggled'), false);
+        assert.equal(wrapper.find('Toggle').prop('toggled'), false);
     });
 
     it('should trigger input.onChange with true after being checked', () => {


### PR DESCRIPTION
In forms we have error when switching the first time on BooleanInput
because value is null (component uncontrolled) and it becomes
controlled.
Changing that props won't show the error anymore but the value at the
first time is still null : that's BAD