### PR TITLE
filter: changer the delays before fetching data

### DIFF
--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -92,7 +92,7 @@ Filter.propTypes = {
 };
 
 Filter.defaultProps = {
-    debounce: 1000,
+    debounce: 500,
 };
 
 export default withPermissionsFilteredChildren(Filter);

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -92,7 +92,7 @@ Filter.propTypes = {
 };
 
 Filter.defaultProps = {
-    debounce: 500,
+    debounce: 1000,
 };
 
 export default withPermissionsFilteredChildren(Filter);

--- a/src/mui/list/InfiniteList.js
+++ b/src/mui/list/InfiniteList.js
@@ -42,19 +42,6 @@ export class InfiniteList extends List {
         this.props.changeListParams(this.props.resource, this.props.query);
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        if (
-            (nextProps.isLoading === this.props.isLoading &&
-                nextProps.width === this.props.width &&
-                nextProps.version === this.props.version &&
-                nextState === this.state) ||
-            (nextProps.isLoading &&
-                nextProps.params.page === this.props.params.page)
-        ) {
-            return false;
-        }
-        return true;
-    }
 
     getQuery() {
         const query =


### PR DESCRIPTION
by default AOR make 500 ms before request fetch, we noticed that is to
speed for the users, now we set this value to 1000 ms. We do this in
order to have more time before fetching news data for now.
It will be powerfull if all the filters action are dissociated to the
list component.