### PR TITLE
InfiniteList: fix range not satisfiable

### DIFF
--- a/src/mui/list/InfiniteList.js
+++ b/src/mui/list/InfiniteList.js
@@ -79,7 +79,9 @@ export class InfiniteList extends List {
     }
 
     getNextPage() {
-        this.changeParams({ type: 'INC_PAGE' });
+        if (this.props.hasMore) {
+            this.changeParams({ type: 'INC_PAGE' });
+        }
     }
 
     render() {


### PR DESCRIPTION
Loadmore props defined by react-infinite-scroller should properly call
loadmore (props of react-infinite-scroller) if hasmore props is equal
to true. But we don't protect react-infinite-scroller with loadmore
function. Now we check if hasmore props is correctly equal to true. We
do this in order call fetch action if hasmore is equal to true. Now we
don't have range not satisfiable message error.