### PR TITLE
Admin/redux-persist:Not using PersistGate if no reducer is persisted

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -63,6 +63,7 @@ const Admin = ({
     sagaMiddleware.run(saga);
 
     const persistor = persistStore(store);
+    const registry = persistor.getState().registry;
 
     const logout = authClient ? createElement(logoutButton || Logout) : null;
 
@@ -81,51 +82,60 @@ const Admin = ({
         return null;
     };
 
-    return (
-        <Provider store={store}>
-          <PersistGate loading={null} persistor={persistor}>
-            <TranslationProvider messages={messages}>
-                <ConnectedRouter history={routerHistory}>
-                    <Switch>
-                        {loginPage && (
-                            <Route
-                                exact
-                                path="/login"
-                                render={({ location }) => {
-                                    logPageView();
-                                    return createElement(loginPage, {
-                                        location,
-                                        title,
-                                        theme,
-                                    });
-                                }}
-                            />
-                        )}
+    const AdminContent = () => {
+      return (
+        <TranslationProvider messages={messages}>
+            <ConnectedRouter history={routerHistory}>
+                <Switch>
+                    {loginPage && (
                         <Route
-                            path="/"
-                            render={routeProps => {
+                            exact
+                            path="/login"
+                            render={({ location }) => {
                                 logPageView();
-                                return (
-                                    <AdminRoutes
-                                        appLayout={appLayout}
-                                        catchAll={catchAll}
-                                        customRoutes={customRoutes}
-                                        dashboard={dashboard}
-                                        logout={logout}
-                                        menu={menu}
-                                        theme={theme}
-                                        title={title}
-                                        {...routeProps}
-                                    >
-                                        {children}
-                                    </AdminRoutes>
-                                );
+                                return createElement(loginPage, {
+                                    location,
+                                    title,
+                                    theme,
+                                });
                             }}
                         />
-                    </Switch>
-                </ConnectedRouter>
-            </TranslationProvider>
-          </PersistGate>
+                    )}
+                    <Route
+                        path="/"
+                        render={routeProps => {
+                            logPageView();
+                            return (
+                                <AdminRoutes
+                                    appLayout={appLayout}
+                                    catchAll={catchAll}
+                                    customRoutes={customRoutes}
+                                    dashboard={dashboard}
+                                    logout={logout}
+                                    menu={menu}
+                                    theme={theme}
+                                    title={title}
+                                    {...routeProps}
+                                >
+                                    {children}
+                                </AdminRoutes>
+                            );
+                        }}
+                    />
+                </Switch>
+            </ConnectedRouter>
+        </TranslationProvider>
+      );
+    }
+
+    return (
+        <Provider store={store}>
+          {registry.length ?
+            <PersistGate loading={null} persistor={persistor}>
+              <AdminContent />
+            </PersistGate> :
+            <AdminContent />
+          }
         </Provider>
     );
 };


### PR DESCRIPTION
Persisted reducer states are supposed to be rehydrated on app launch. If there is no persisted reducer, this rehydration doesn't happen and it causes PersistGate not to render its children.
Thus, a condition must be set on the number of persisted reducers inside Admin rendering, here readin registry length.